### PR TITLE
Fix queue time logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ export const middleware = ({ appName, host, port, queueHeader }) => expressStats
      */
 
     const getQueueDuration = () => req.header(queueHeader)
-      ? new Date().getTime() - req.headers(queueHeader)
+      ? new Date().getTime() - req.header(queueHeader)
       : null
 
     /* Get and normalize the request method (e.g., `'get'`, `'post'`, `'put'`) */

--- a/index.js
+++ b/index.js
@@ -70,10 +70,10 @@ export const middleware = ({ appName, host, port, queueHeader }) => expressStats
     /* Report the time of the request duration (e.g., `redo-graphql.request.post.graphql:4|ms`) */
     client.timing(metricName, getRequestDuration())
 
-    /* Report the time the request has been in queue (e.g., `redo-graphql.request.post.graphql.request.queue:5|ms`) */
+    /* Report the time the request has been in queue (e.g., `redo-graphql.request.post.graphql.queue:5|ms`) */
     const queueDuration = getQueueDuration()
     if (queueDuration) {
-      client.timing(`${metricName}.request.queue`, queueDuration)
+      client.timing(`${metricName}.queue`, queueDuration)
     }
   }
 })

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redo-monolith",
   "version": "0.1.0",
   "description": "",
-  "main": "index.js",
+  "main": "./dist/index.js",
   "scripts": {
     "build": "babel index.js --out-dir dist",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- We were accessing `express`'s `req.headers` methods, that does not exists. It was failing silently and sending nothing to the `statsd` daemon.
- Fixed wrong metric name
- Fix `package.json` bad reference to the compiled assets