### PR TITLE
Measure queue time until the beginning of the request

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -30,7 +30,7 @@ export const getStatusType = statusCode => {
  * @return {Number} Time in ms since the request started
  */
 
-export const getRequestDuration = startTime => new Date().getTime() - startTime
+export const getRequestDuration = startTime => microtime.nowDouble() - startTime
 
 /**
  * Gets the time in ms since the request has been enqueued in the web server.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,12 +40,11 @@ export const getRequestDuration = startTime => new Date().getTime() - startTime
  * @return {Number} The time in ms since the request has been enqueued
  */
 
-export const getQueueDuration = (req, queueHeader) => {
+export const getQueueDuration = (req, queueHeader, startTime) => {
   if (!req.header(queueHeader)) {
     return
   }
 
   const queueTime = +req.header(queueHeader).replace('t=', '')
-  const now = microtime.nowDouble()
-  return now - queueTime
+  return startTime - queueTime
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import Lynx from 'lynx'
+import microtime from 'microtime'
 import { getQueueDuration, getRequestDuration, getStatusType } from './helpers'
 
 const noop = () => undefined
@@ -7,11 +8,11 @@ export default ({ host, port, queueHeader }) => {
   const client = new Lynx(host, port)
 
   const middleware = ({ send = noop } = {}) => (req, res, next) => {
-    const startTime = new Date().getTime()
+    const startTime = microtime.nowDouble()
 
     const sendData = () => send({
       client,
-      queueDuration: getQueueDuration(req, queueHeader),
+      queueDuration: getQueueDuration(req, queueHeader, startTime),
       requestDuration: getRequestDuration(startTime),
       status: getStatusType(res.statusCode.toString()),
       req,


### PR DESCRIPTION
Before this, we were measuring the queue time until the end of the request, which includes the running time.

Closes #8 