### PR TITLE
Report times in milliseconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redo-monolith",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -25,19 +25,19 @@ export const getStatusType = statusCode => {
 }
 
 /**
- * Gets the time in ms since the request started
+ * Gets the time in seconds since the request started
  *
- * @return {Number} Time in ms since the request started
+ * @return {Number} Time in seconds since the request started
  */
 
 export const getRequestDuration = startTime => microtime.nowDouble() - startTime
 
 /**
- * Gets the time in ms since the request has been enqueued in the web server.
+ * Gets the time in seconds since the request has been enqueued in the web server.
  * It is assumed that the `queueHeader` has the value in the format `t=123456.7890` where `123456.7890` is the
- * time in ms since epoch.
+ * time in seconds since epoch.
  *
- * @return {Number} The time in ms since the request has been enqueued
+ * @return {Number} The time in seconds since the request has been enqueued
  */
 
 export const getQueueDuration = (req, queueHeader, startTime) => {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,14 @@ import { getQueueDuration, getRequestDuration, getStatusType } from './helpers'
 
 const noop = () => undefined
 
+/**
+ * Convert a time in seconds to milliseconds
+ * @param {Number} seconds A time in seconds
+ * @return {Number} The same time, but in milliseconds
+ */
+
+const toMilliseconds = seconds => seconds * 1000
+
 export default ({ host, port, queueHeader }) => {
   const client = new Lynx(host, port)
 
@@ -12,8 +20,8 @@ export default ({ host, port, queueHeader }) => {
 
     const sendData = () => send({
       client,
-      queueDuration: getQueueDuration(req, queueHeader, startTime),
-      requestDuration: getRequestDuration(startTime),
+      queueDuration: toMilliseconds(getQueueDuration(req, queueHeader, startTime)),
+      requestDuration: toMilliseconds(getRequestDuration(startTime)),
       status: getStatusType(res.statusCode.toString()),
       req,
       res


### PR DESCRIPTION
`microtime#nowDouble` gets the time in seconds. Also, the queue time header delivers the time in seconds. We were assuming that all those times are in ms, so I fixed the comments.
Also, the library should deliver to `statsd` the times in ms, so I added a conversion from seconds to ms after the calculations are made.

Closes #10 